### PR TITLE
Wait for serial connection before printing

### DIFF
--- a/03_Firmware/main.ino
+++ b/03_Firmware/main.ino
@@ -1,5 +1,8 @@
 void setup() {
   Serial.begin(115200);
+  while (!Serial) {
+    ; // wait for serial port to connect. Needed for native USB
+  }
   Serial.println("SlopeBot DZ MK1 Test-Upload erfolgreich.");
 }
 


### PR DESCRIPTION
## Summary
- ensure the main firmware waits for serial connection before sending output

## Testing
- `arduino-cli compile 03_Firmware` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a42d26a7f0832ebd3d648a2c066215