### PR TITLE
Add serial output startup test

### DIFF
--- a/03_Firmware/Tests/README.md
+++ b/03_Firmware/Tests/README.md
@@ -1,0 +1,22 @@
+# Tests
+
+## serial_output_test.ino
+
+Dieser Arduino-Unit-Test bindet die Firmware `../main.ino` ein und prüft,
+ob beim Start die Meldung `SlopeBot DZ MK1 Test-Upload erfolgreich.` an die
+serielle Schnittstelle gesendet wird. Die Ausgabe von `Serial` wird dabei
+abgefangen, damit der Test automatisch verifiziert werden kann.
+
+### Ausführung
+
+1. [Arduino CLI](https://arduino.github.io/arduino-cli/latest/) und das
+   passende Board-Paket installieren.
+2. In dieses Verzeichnis wechseln und den Sketch kompilieren und hochladen:
+
+   ```bash
+   arduino-cli compile --fqbn <FQBN> serial_output_test.ino
+   arduino-cli upload  --fqbn <FQBN> -p <PORT> serial_output_test.ino
+   ```
+
+3. Serielle Konsole mit `115200` Baud öffnen. Der Test startet automatisch
+   und meldet das Ergebnis.

--- a/03_Firmware/Tests/serial_output_test.ino
+++ b/03_Firmware/Tests/serial_output_test.ino
@@ -1,0 +1,43 @@
+#include <Arduino.h>
+#include <unity.h>
+
+class TestSerial : public Print {
+public:
+  String output;
+  void begin(unsigned long) {}
+  size_t write(uint8_t ch) override {
+    output += static_cast<char>(ch);
+    return 1;
+  }
+} testSerial;
+
+#define Serial testSerial
+#define setup main_setup
+#define loop main_loop
+#include "../main.ino"
+#undef setup
+#undef loop
+#undef Serial
+
+void setUp(void) {
+  testSerial.output = "";
+}
+
+void tearDown(void) {}
+
+void test_serial_output_startup(void) {
+  main_setup();
+  TEST_ASSERT_EQUAL_STRING(
+      "SlopeBot DZ MK1 Test-Upload erfolgreich.\r\n",
+      testSerial.output.c_str());
+}
+
+void setup() {
+  Serial.begin(115200);
+  UNITY_BEGIN();
+  RUN_TEST(test_serial_output_startup);
+  UNITY_END();
+}
+
+void loop() {}
+


### PR DESCRIPTION
## Summary
- add Arduino unit test verifying that `main.ino` prints the expected startup message to serial
- document how to compile and upload the test sketch

## Testing
- `arduino-cli compile --fqbn arduino:avr:uno 03_Firmware/Tests/serial_output_test.ino` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a42e44bc8c832ebe1696ad0d519f0a